### PR TITLE
remove permalinks with trailing slash and redundant layout config

### DIFF
--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Discussion
-permalink: /discuss/
 ---
 
 ## Preguntas frecuentes
@@ -455,4 +453,3 @@ El último paso, como antes, es comprometer nuestro cambio al repositorio:
 $ git commit -m 'Superman's home is Earth, told you before.'
 ~~~
 {: .language-bash}
-	

--- a/_extras/figures.md
+++ b/_extras/figures.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: Figures
-permalink: /figures/
 ---
 {% include all_figures.html %}

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,14 +1,12 @@
 ---
-layout: page
 title: "Instructor Notes"
-permalink: /guide/
 ---
 
 Usar una herramienta de software para manejar las versiones de tus archivos de proyecto
 le permite enfocarse en los aspectos más interesantes / innovadores de su proyecto.
 
 * Ventajas del control de versiones
-    * Es fácil de configurar 
+    * Es fácil de configurar
     * Cada copia de un repositorio de Git es una copia de seguridad completa de un proyecto y su historial
     * Unos pocos comandos fáciles de recordar son todo lo que necesita para la mayoría de las tareas cotidianas de control de versiones
     * El servicio de alojamiento [GitHub][github] proporciona un servicio de colaboración basado en la web


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Software Carpentry Lessons page](https://software-carpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I also removed the `layout` field in the YAML front matter, as this is a default defined in `_config.yml` too.

If and when this PR is merged, I'll update the link on https://software-carpentry.org/lessons/ to the Instructor Notes page for this lesson to avoid a broken link there, and make another sweep through the lesson pages to ensure we're not breaking any internal links too. 